### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Clone this repository wherever you want and follow the instructions in the next 
 #### Over the network
 1. Replace network info with your own in **util.py** (local network by default)
 2. Run the server (Bob): `make bob`
-3. Run the client with the path of a json circuit as argument: `make alice <json_circuit>`
+3. Run the client with the path of a json circuit as argument: `make <circuit-name>` e.g. `make add`
 
 You can also run `make alice` to evaluate all basic circuits present in **json/**.
 


### PR DESCRIPTION
Executing individual circuits using `make alice <json_circuit>` does not work.
That command executes all the circuits, this appears to be a side effect of the make file.

Although, passing the circuit name as the argument works all right,
for example, `make add` executes all the add circuits.

After reading the Makefile, this seems to be the intended use, this commit only reflects those changes.

Thank you.